### PR TITLE
fixes NPE when pitest-junit5-plugin cannot be found

### DIFF
--- a/src/main/java/com/valantic/intellij/plugin/mutation/services/impl/DependencyService.java
+++ b/src/main/java/com/valantic/intellij/plugin/mutation/services/impl/DependencyService.java
@@ -22,6 +22,7 @@ import com.intellij.ide.plugins.PluginManagerCore;
 import com.intellij.openapi.components.Service;
 import com.intellij.openapi.extensions.PluginId;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.nio.file.Path;
 import java.util.Arrays;
@@ -42,8 +43,9 @@ public final class DependencyService {
      * @param nameExpression regex expression for file name
      * @return jar file from plugin dependencies
      */
+    @Nullable
     public File getThirdPartyDependency(final String nameExpression) {
-        return Arrays.stream(Optional.of(PluginId.findId(PLUGIN_ID))
+        return Arrays.stream(Optional.ofNullable(PluginId.findId(PLUGIN_ID))
                         .map(PluginManagerCore::getPlugin)
                         .map(IdeaPluginDescriptor::getPluginPath)
                         .map(path -> path.resolve(LIB_PATH))


### PR DESCRIPTION
Hi! I installed version 1.4.0 from github, and immediately got an exception when trying to "Mutate tests". Funnily enough, the test was a junit5 test.
The PR fixes a pop-up in the IDE immediately after launch.

`return dependencyService.getThirdPartyDependency(JUNIT5_PITEST_SUPPORT_PLUGIN_EXPRESSION).getAbsolutePath();`

The value returned by `getThirdPartyDependency` was `null` and thus crashed when trying to invoke `getAbsolutePath` on it.